### PR TITLE
The great rename.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "kmip2pkcs11"
+version = "0.1.0"
+dependencies = [
+ "bcder",
+ "clap",
+ "cryptoki",
+ "daemonbase",
+ "domain",
+ "hex",
+ "kmip-protocol",
+ "kmip-ttlv",
+ "log",
+ "moka",
+ "r2d2",
+ "rand 0.9.1",
+ "rcgen",
+ "rpki",
+ "rustls 0.23.29",
+ "serde",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "toml",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,31 +875,6 @@ dependencies = [
  "tagptr",
  "thiserror",
  "uuid",
-]
-
-[[package]]
-name = "nameshed-hsm-relay"
-version = "0.1.0"
-dependencies = [
- "bcder",
- "clap",
- "cryptoki",
- "daemonbase",
- "domain",
- "hex",
- "kmip-protocol",
- "kmip-ttlv",
- "log",
- "moka",
- "r2d2",
- "rand 0.9.1",
- "rcgen",
- "rpki",
- "rustls 0.23.29",
- "serde",
- "tokio",
- "tokio-rustls 0.26.2",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "nameshed-hsm-relay"
+name = "kmip2pkcs11"
 version = "0.1.0"
 edition = "2024"
-authors = ["NLnet Labs <nameshed@nlnetlabs.nl>"]
-description = "KMIP to PKCS#11 HSM relay for the Nameshed project."
-repository = "https://github.com/NLnetLabs/nameshed-hsm-relay/"
+authors = ["NLnet Labs <rust-team@nlnetlabs.nl>"]
+description = "A KMIP to PKCS#11 HSM relay for the Cascade project."
+repository = "https://github.com/NLnetLabs/kmip2pkcs11/"
 keywords = ["KMIP", "PKCS#11", "HSM", "Rust"]
 categories = ["cryptography"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 > (!) _This project is at an experimental stage and is very much a work-in-progress. It should not be used in production deployments at this time. Furthermore the functionality and interfaces offered should be considered unstable._
 
-# Nameshed HSM Relay
+# A KMIP to PKCS#11 Relay
 
 This Rust application accepts [KMIP](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=39d0c648-0a66-4f46-b343-018dc7d3f19c) requests, converts them to [PKCS#11](https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=922ef643-1e10-4d65-a5ea-018dc7d3f0a4) format and executes them against a loaded PKCS#11 library.
 
 ## Use cases
 
-### Intended use case: shielding Nameshed against an untrusted PKCS#11 library
+### Intended use case: shielding Cascade against an untrusted PKCS#11 library
 
-The use case for which this application is primarily being developed is to enable [Nameshed](https://github.com/NLnetLabs/nameshed/) to make use of a Hardware Security Module (HSM) via a PKCS#11 interface without having to load an untrusted 3rd party PKCS#11 library into its process.
+The use case for which this application is primarily being developed is to enable [Cascade](https://github.com/NLnetLabs/cascade/) to make use of a Hardware Security Module (HSM) via a PKCS#11 interface without having to load an untrusted 3rd party PKCS#11 library into its process.
 
 This is particularly important for a Rust application as the PKCS#11 interface exposes the application to code that is likely not protected by the guarantees provided by the Rust compiler, as the PKCS#11 is a foreign function interface beyond which the Rust compiler cannot see.
 
@@ -16,7 +16,7 @@ If the PKCS#11 library experiences a fatal error that may not be reason to exit 
 
 ### Other use cases
 
-This project could potentially act as the basis for a general purpose KMIP to PKCS#11 relay. However, at present and for the foreseeable future we plan only to implement the tiny fraction of the KMIP specification needed by the Nameshed project, and the only KMIP client that will be tested against will be Nameshed.
+This project could potentially act as the basis for a general purpose KMIP to PKCS#11 relay. However, at present and for the foreseeable future we plan only to implement the tiny fraction of the KMIP specification needed by the Cascade project, and the only KMIP client that will be tested against will be Cascade.
 
 However, the supported requests cover only the small fraction of the KMIP specificationthis application implements support for only a limited fraction of the entire interface defined by the applicable versions of the KMIP and PKCS#11 specifications, specifically whatever is needed to power our own projects.
 
@@ -56,7 +56,7 @@ The following KMIP operations are supported by this application at present:
 # Usage
 
 ```
-$ nameshed-hsm-relay
+$ kmip2pkcs11
 error: the following required arguments were not provided:
   --server-cert <SERVER_CERT_PATH>
   --server-key <SERVER_KEY_PATH>

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), ExitError> {
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_name("nameshed-worker")
+        .thread_name("kmip2pkcs11-worker")
         .build()
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,10 @@ fn main() -> Result<(), ExitError> {
     Logger::init_logging()?;
 
     let matches = Config::config_args(
-        Command::new("nameshed-hsm-relay")
+        Command::new("kmip2pkcs11")
             .version(crate_version!())
             .author(crate_authors!())
-            .about("Nameshed HSM Relay"),
+            .about("A KMIP to PKCS#11 relay"),
     )
     .get_matches();
     let (mut config, args) = Config::from_arg_matches(&matches)?;


### PR DESCRIPTION
Replaces references to Nameshed with Cascade and renames the project from Nameshed-HSM-Relay to `kmip2pkcs11` (to which there was actually still one reference left behind in the README from the original name).

Also replaces the team email address with `rust-team@nlnetlabs.nl`.